### PR TITLE
Changed based on "Clearing Up Confusion Around baseurl" by @parkr

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ description: > # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
-baseurl: "/knitr-jekyll/" # the subpath of your site, e.g. /blog/
+baseurl: "/knitr-jekyll" # the subpath of your site, e.g. "/blog". For explanation, see https://byparker.com/blog/2014/clearing-up-confusion-around-baseurl/ 
 url: "http://yourdomain.com" # the base hostname & protocol for your site
 permalink: /:year/:month/:title.html
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,7 +6,7 @@
     <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
     <meta name="description" content="{{ site.description }}">
 
-    <link rel="stylesheet" href="{{ "css/main.css" | prepend: site.baseurl }}">
+    <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
     <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 </head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <!--- Header and nav template site-wide -->
 <header>
   <nav class="group">
-    <a href="{{ site.baseurl }}"><img class="badge" src="{{ site.baseurl }}/badge.png" alt="CH"></a>
+    <a href="{{ site.baseurl }}\"><img class="badge" src="{{ site.baseurl }}/badge.png" alt="CH"></a>
     {% for page in site.pages %}
       {% if page.title %}
         <a class="page-link" href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,11 +1,11 @@
 <!--- Header and nav template site-wide -->
 <header>
-    <nav class="group">
-		<a href="{{ site.baseurl }}"><img class="badge" src="{{ badge.png | prepend: site.baseurl }}/badge.png" alt="CH"></a>
+  <nav class="group">
+    <a href="{{ site.baseurl }}"><img class="badge" src="{{ site.baseurl }}/badge.png" alt="CH"></a>
     {% for page in site.pages %}
       {% if page.title %}
         <a class="page-link" href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
-        {% endif %}
+      {% endif %}
     {% endfor %}
-	</nav>
+  </nav>
 </header>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,6 @@ layout: default
     {% endfor %}
   </ul>
 
-  <p class="rss-subscribe">subscribe <a href="{{ "feed.xml" | prepend: site.baseurl }}">via RSS</a></p>
+  <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p>
 
 </div>


### PR DESCRIPTION
Made changes based on [Clearing Up Confusion Around baseurl](https://byparker.com/blog/2014/clearing-up-confusion-around-baseurl/)

url and baseurl should not have trailing slashes.

Tested this with a baseurl of "" and a baseurl of "/knitr-jekyll" - Both worked successfully.
